### PR TITLE
Added date string.  Simplified UI declaration

### DIFF
--- a/js/gis/dijit/TimeSlider.js
+++ b/js/gis/dijit/TimeSlider.js
@@ -7,7 +7,6 @@ define([
     'dojo/dom-attr',
     'dojo/dom-construct',
     'dojo/dom-style',
-    'dojo/on',
     'dijit/form/DateTextBox',
     'dijit/form/Button',
     'esri/TimeExtent',
@@ -16,15 +15,13 @@ define([
     'dojo/i18n!./TimeSlider/nls/resource',
     'xstyle/css!./TimeSlider/css/TimeSlider.css'
 ], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, lang, domAttr,
-  domConst, domStyle, on, DateTextBox, Button, TimeExtent, TimeSlider, TimeSliderTemplate, i18n, css) {
+  domConst, domStyle, DateTextBox, Button, TimeExtent, TimeSlider, TimeSliderTemplate, i18n, css) {
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         widgetsInTemplate: true,
         templateString: TimeSliderTemplate,
         i18n: i18n,
         enable: false,
         postCreate: function () {
-            // Hide timeslider control bar
-            domStyle.set(this.timeSliderControlsContainer, 'display', 'none');
             this.timesliderbtn.title = this.i18n.timesliderbntTIP;
             // Create time slider
             this.timeSlider = new TimeSlider({
@@ -58,7 +55,7 @@ define([
 
             this.toDateLabel.innerHTML = this.i18n.to;
             this.toDate.value = to;
-            on(this.toDate, 'change', lang.hitch(this, this._toDateChange));
+            this.toDate.on('change', lang.hitch(this, this._toDateChange));
 
             this.setButton.on('click', lang.hitch(this, this._setTimeSlider));
         },

--- a/js/gis/dijit/TimeSlider.js
+++ b/js/gis/dijit/TimeSlider.js
@@ -6,6 +6,8 @@ define([
     'dojo/_base/lang',
     'dojo/dom-attr',
     'dojo/dom-construct',
+    'dojo/dom-style',
+    'dojo/on',
     'dijit/form/DateTextBox',
     'dijit/form/Button',
     'esri/TimeExtent',
@@ -14,35 +16,23 @@ define([
     'dojo/i18n!./TimeSlider/nls/resource',
     'xstyle/css!./TimeSlider/css/TimeSlider.css'
 ], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin, lang, domAttr,
-             domConst, DateTextBox, Button, TimeExtent, TimeSlider, TimeSliderTemplate, i18n, css) {
+  domConst, domStyle, on, DateTextBox, Button, TimeExtent, TimeSlider, TimeSliderTemplate, i18n, css) {
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         widgetsInTemplate: true,
         templateString: TimeSliderTemplate,
         i18n: i18n,
-        timeExtent: null,
-        timeSlider: null,
-        setToLabel: null,
-        setTo: null,
-        setFromLabel: null,
-        setFrom: null,
-        setButton: null,
-        timeSliderEnableStyle: 'position:absolute;top:55px;left:90px;z-index:50;width:475px;display: inline;background-color:#F5F5F5;height:40px;padding-top:5px;',
-        setFromLabelEnableStyle: 'position:absolute;top:20px;left:90px;z-index:40;width:210px;padding:10px;display: inline;background-color:#F5F5F5;',
-        setToLabelEnableStyle: 'position:absolute;top:20px;left:315px;z-index:40;width:230px;padding:10px;display: inline;background-color:#F5F5F5;',
-        setFromEnableStyle: 'position:absolute;top:22px;left:195px;z-index:50;width:400px;display: inline;width:120px;',
-        setToEnableStyle: 'position:absolute;top:22px;left:365px;z-index:50;width:400px;display: inline;width:120px;',
-        setButtonEnableStyle: 'position:absolute;top:22px;left:495px;z-index:50;width:60px;display: inline;width:60px;',
-        disableStyle: 'display: none;',
         enable: false,
         postCreate: function () {
-
+            // Hide timeslider control bar
+            domStyle.set(this.timeSliderControlsContainer, 'display', 'none');
             this.timesliderbtn.title = this.i18n.timesliderbntTIP;
-
+            // Create time slider
             this.timeSlider = new TimeSlider({
                 style: 'width: 100%;'
-            }, domConst.create('div', {}, this.map.id));
-            domAttr.set(this.timeSlider.domNode, 'style', this.timeSliderDisableStyle);
+            }, this.timesliderDiv);
+            this.map.setTimeSlider(this.timeSlider);
 
+            // Create time extent for map
             this.timeExtent = new TimeExtent();
             var from = new Date();
             from.setDate(from.getDate() - 5);
@@ -52,82 +42,57 @@ define([
             this.timeExtent.endTime = to;
             this.timeSlider.setThumbCount(2);
             this.timeSlider.createTimeStopsByTimeInterval(this.timeExtent, 1, 'esriTimeUnitsDays');
-            this.timeSlider.setThumbIndexes([0,1]);
+            this.timeSlider.setThumbIndexes([0, 1]);
             this.timeSlider.setThumbMovingRate(2000);
             this.timeSlider.startup();
+            this.map.setTimeSlider(this.timeSlider);
+            
+            this.timeSlider.on('time-extent-change', lang.hitch(this, function (evt) {
+                this.dateIndicatorText.innerHTML = this._formatDate(evt.startTime) + ' - ' + this._formatDate(evt.endTime);
+            }));
 
-            this.setFromLabel = domConst.create('div', {}, this.map.id);
-            this.setFromLabel.innerHTML = '<i>' + this.i18n.from  + '<\/i>';
-            this.setFrom = new DateTextBox({
-                title: 'From',
-                name: 'From',
-                value: from,
-                onChange: lang.hitch(this, '_setFromChange')
-            }, domConst.create('div', {}, this.map.id));
+            this.fromDateLabel.innerHTML = this.i18n.from;
+            this.fromDate.value = from;
+            this.fromDate.on('change', lang.hitch(this, this._fromDateChange));
+            
 
-            this.setToLabel = domConst.create('div', {}, this.map.id);
-            this.setToLabel.innerHTML = '<i>' + this.i18n.to  + '<\/i>';
-            this.setTo = new DateTextBox({
-                title: 'To',
-                name: 'To',
-                value: to,
-                onChange: lang.hitch(this, '_setToChange')
-            }, domConst.create('div', {}, this.map.id));
+            this.toDateLabel.innerHTML = this.i18n.to;
+            this.toDate.value = to;
+            on(this.toDate, 'change', lang.hitch(this, this._toDateChange));
 
-            this.setButton = new Button({
-                label: 'ΟΚ',
-                onClick: lang.hitch(this, '_setTimeSlider')
-            }, domConst.create('div', {}, this.map.id));
-
-            var t = this;
-            this.timeSlider.on('time-extent-change', function(evt) {
-                t.setFrom.set('value', evt.startTime);
-                t.setTo.set('value', evt.endTime);
-            });
-
+            this.setButton.on('click', lang.hitch(this, this._setTimeSlider));
         },
+
+            
         EnableTimeSlider: function () {
-            if(!this.enable){
-                this.map.setTimeSlider(this.timeSlider);
-                domAttr.set(this.timeSlider.domNode, 'style', this.timeSliderEnableStyle);
-                domAttr.set(this.setFromLabel, 'style', this.setFromLabelEnableStyle);
-                domAttr.set(this.setToLabel, 'style', this.setToLabelEnableStyle);
-                domAttr.set(this.setFrom, 'style', this.setFromEnableStyle);
-                domAttr.set(this.setTo, 'style', this.setToEnableStyle);
-                domAttr.set(this.setButton, 'style', this.setButtonEnableStyle);
+            if (!this.enable) {
+                domStyle.set(this.timeSliderControlsContainer, 'display', '');
                 this.enable = true;
                 this.timesliderbtn.title = this.i18n.timesliderbntTIPdis;
-            }
-            else
-            {
-                var timeExtent = new TimeExtent();
-                timeExtent.startTime = new Date('1/1/1990 UTC');
-                var dt = new Date();
-                dt.setDate(dt.getDate() + 1);
-                timeExtent.endTime = dt;
-                this.map.setTimeExtent(timeExtent);
-                domAttr.set(this.timeSlider.domNode, 'style', this.disableStyle);
-                domAttr.set(this.setFromLabel, 'style', this.disableStyle);
-                domAttr.set(this.setToLabel, 'style', this.disableStyle);
-                domAttr.set(this.setFrom, 'style', this.disableStyle);
-                domAttr.set(this.setTo, 'style', this.disableStyle);
-                domAttr.set(this.setButton, 'style', this.disableStyle);
+            } else {
+                domStyle.set(this.timeSliderControlsContainer, 'display', 'none');
                 this.enable = false;
                 this.timesliderbtn.title = this.i18n.timesliderbntTIP;
             }
         },
-        _setFromChange: function(evt){
-            this.setTo.constraints.min = evt;
+        _fromDateChange: function (evt) {
+            if (evt) {
+                this.toDate.constraints.min = evt;
+            }
         },
-        _setToChange: function(evt){
-            this.setFrom.constraints.max = evt;
+        _toDateChange: function (evt) {
+            if (evt) {
+                this.fromDate.constraints.max = evt;
+            }
         },
-        _setTimeSlider: function(){
-            this.timeExtent.startTime = this.setFrom.value;
-            this.timeExtent.endTime = this.setTo.value;
+        _setTimeSlider: function () {
+            this.timeExtent.startTime = this.fromDate.value;
+            this.timeExtent.endTime = this.toDate.value;
             this.timeSlider.createTimeStopsByTimeInterval(this.timeExtent, 1, 'esriTimeUnitsDays');
             this.timeSlider.startup();
-
+        },
+        _formatDate: function(date) {
+            return date.toDateString();
         }
     });
 });

--- a/js/gis/dijit/TimeSlider.js
+++ b/js/gis/dijit/TimeSlider.js
@@ -49,12 +49,12 @@ define([
             }));
 
             this.fromDateLabel.innerHTML = this.i18n.from;
-            this.fromDate.value = from;
+            this.fromDate.set('value', from);
             this.fromDate.on('change', lang.hitch(this, this._fromDateChange));
             
 
             this.toDateLabel.innerHTML = this.i18n.to;
-            this.toDate.value = to;
+            this.toDate.set('value', to);
             this.toDate.on('change', lang.hitch(this, this._toDateChange));
 
             this.setButton.on('click', lang.hitch(this, this._setTimeSlider));

--- a/js/gis/dijit/TimeSlider.js
+++ b/js/gis/dijit/TimeSlider.js
@@ -44,6 +44,7 @@ define([
             this.timeSlider.startup();
             this.map.setTimeSlider(this.timeSlider);
             
+            this.dateIndicatorText.innerHTML = this._formatDate(from) + ' - ' + this._formatDate(to);
             this.timeSlider.on('time-extent-change', lang.hitch(this, function (evt) {
                 this.dateIndicatorText.innerHTML = this._formatDate(evt.startTime) + ' - ' + this._formatDate(evt.endTime);
             }));

--- a/js/gis/dijit/TimeSlider/css/TimeSlider.css
+++ b/js/gis/dijit/TimeSlider/css/TimeSlider.css
@@ -1,8 +1,11 @@
 .gis_TimeSliderDijit {
-	height: 16px;
+    height: 16px;
 }
 
 .gis_TimeSliderDijit #timesliderbtn {
+    position: absolute;
+    left: 19px;
+    top: 180px;
     padding: 0;
     width: 34px;
     height: 34px;
@@ -17,6 +20,18 @@
 }
 
 .gis_TimeSliderDijit .formContainer {
-    /*border: 1px solid #bbb;*/
     width: 50px;
+}
+
+#timeSliderControlsContainer {
+    position: absolute;
+    top:20px;
+    left:90px;
+    width: 495px;
+    padding:10px;
+    background-color:#F5F5F5;
+}
+
+#timeSliderControlsContainer > div {
+    display: inline-block;
 }

--- a/js/gis/dijit/TimeSlider/templates/TimeSlider.html
+++ b/js/gis/dijit/TimeSlider/templates/TimeSlider.html
@@ -1,5 +1,24 @@
 <div class="gis_TimeSliderDijit" >
     <div class="formContainer">
         <button id="timesliderbtn" title="Ενεργοποίηση Χρόνου" data-dojo-attach-point="timesliderbtn"  data-dojo-attach-event="onClick:EnableTimeSlider"></button>
-	</div>
+  </div>
+    <div id="timeSliderControlsContainer" data-dojo-attach-point="timeSliderControlsContainer">
+        <div class="datepicker-container">
+            <div data-dojo-attach-point="fromDateLabel">Data from</div>
+            <input class="datepicker" type="text" name="from" id="fromDate" value=""
+                data-dojo-type="dijit/form/DateTextBox" data-dojo-attach-point="fromDate"/>
+        </div>
+        <div class="datepicker-container">
+            <div data-dojo-attach-point="toDateLabel">to</div>
+            <input class="datepicker" type="text" name="to" id="toDate" value=""
+                data-dojo-type="dijit/form/DateTextBox" data-dojo-attach-point="toDate"/>
+        </div>
+        <button id="setButton" data-dojo-type="dijit/form/Button" type="button" data-dojo-attach-point="setButton">Set</button>
+        <br>
+        <div data-dojo-attach-point="timesliderDiv"></div>
+        <br>
+        <div>
+            <label data-dojo-attach-point="dateIndicatorText"></label>
+        </div>
+    </div>
 </div>

--- a/js/gis/dijit/TimeSlider/templates/TimeSlider.html
+++ b/js/gis/dijit/TimeSlider/templates/TimeSlider.html
@@ -2,7 +2,7 @@
     <div class="formContainer">
         <button id="timesliderbtn" title="Ενεργοποίηση Χρόνου" data-dojo-attach-point="timesliderbtn"  data-dojo-attach-event="onClick:EnableTimeSlider"></button>
   </div>
-    <div id="timeSliderControlsContainer" data-dojo-attach-point="timeSliderControlsContainer">
+    <div id="timeSliderControlsContainer" data-dojo-attach-point="timeSliderControlsContainer" style="display: none">
         <div class="datepicker-container">
             <div data-dojo-attach-point="fromDateLabel">Data from</div>
             <input class="datepicker" type="text" name="from" id="fromDate" value=""


### PR DESCRIPTION
- Added a date string at bottom to display the timeslider's current time extent, so that the user chosen values in the dateTextBoxes would not be overwritten:
![datestring](https://user-images.githubusercontent.com/6201681/44368303-01fad480-a498-11e8-9fb9-5c381336de54.PNG)


- Encased all of the widget UI elements in one container div that can be shown and hidden, simplifying the enable-disable logic
- CSS changes to handle the new HTML declarations' style

- Renamed some functions and variables for clarity
